### PR TITLE
refactor: [BACK] ErrorCode.java를 Kotlin으로 마이그레이션

### DIFF
--- a/backend/src/main/java/com/back/global/exception/ErrorCode.kt
+++ b/backend/src/main/java/com/back/global/exception/ErrorCode.kt
@@ -1,12 +1,12 @@
-package com.back.global.exception;
+package com.back.global.exception
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatus
 
-@Getter
-@RequiredArgsConstructor
-public enum ErrorCode {
+enum class ErrorCode(
+    val code: String,
+    val message: String,
+    val httpStatus: HttpStatus
+) {
     // 400 Bad Request
     INVALID_INPUT_VALUE("400-1", "잘못된 입력값입니다.", HttpStatus.BAD_REQUEST),
     INVALID_REQUEST_BODY("400-1", "요청 본문이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
@@ -44,11 +44,8 @@ public enum ErrorCode {
     AI_INVALID_JSON("500", "AI 응답이 유효한 JSON 형식이 아닙니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     JSON_PARSING_ERROR("500", "JSON 파싱 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
-    private final String code;
-    private final String message;
-    private final HttpStatus httpStatus;
-
-    public String getMessageWithArgs(Object... args) {
-        return String.format(message, args);
+    // 메시지에 동적 인자가 필요한 경우 사용 (String.format 기능)
+    fun getMessageWithArgs(vararg args: Any?): String {
+        return message.format(*args)
     }
 }


### PR DESCRIPTION
<!--
PR 제목은 이슈와 동일하게 "키워드: 작업 내용"으로 등록해 주세요!
-->

## #️⃣연관된 이슈

close #9 

---

### 작업 내용

기존 Java 기반의 `ErrorCode` 클래스를 Kotlin으로 전환
이 과정에서 불필요한 라이브러리 의존성을 제거하고 Kotlin의 언어적 이점을 활용하여 코드를 더 간결하게 개선

### 변경 사항

**1. Java Enum에서 Kotlin Enum으로 전환**

* 기존 `ErrorCode.java` 파일을 삭제하고 동일한 도메인 로직을 가진 Kotlin 파일로 재작성
* Kotlin의 주 생성자(Primary Constructor)를 사용하여 `code`, `message`, `httpStatus` 프로퍼티를 선언함으로써 보일러플레이트 코드를 최소화

**2. Lombok 의존성 제거**

* 기존 Java 코드에서 필드 접근과 생성자 생성을 위해 사용하던 `@Getter` 및 `@RequiredArgsConstructor` 어노테이션을 제거
* Kotlin의 `val` 키워드를 통해 불변 프로퍼티를 정의하여 데이터의 안정성을 향상

**3. 가변 인자(Variable Arguments) 처리 방식 개선**

* `getMessageWithArgs` 메서드의 파라미터 타입을 Java의 `Object...`에서 Kotlin의 `vararg Any?`로 변경
* `String.format()` 호출 시 스프레드 연산자(`*args`)를 사용하여 Kotlin의 표준 포맷팅 방식에 맞게 수정