### PR TITLE
fix: BaseInitData의 ItemCreateRequest categoryId 타입 불일치 오류 해결

### DIFF
--- a/backend/src/main/java/com/back/global/initData/BaseInitData.kt
+++ b/backend/src/main/java/com/back/global/initData/BaseInitData.kt
@@ -71,7 +71,7 @@ class BaseInitData(
         itemService.createItem(
             user1.id,
             ItemCreateRequest(
-                categoryId = bathroom.id,
+                categoryId = bathroom.id!!,
                 name = "칫솔",
                 imgUrl = "https://example.com/toothbrush.png",
                 image = null,
@@ -83,7 +83,7 @@ class BaseInitData(
         itemService.createItem(
             user1.id,
             ItemCreateRequest(
-                categoryId = kitchen.id,
+                categoryId = kitchen.id!!,
                 name = "수세미",
                 imgUrl = "https://example.com/sponge.png",
                 image = null,
@@ -95,7 +95,7 @@ class BaseInitData(
         itemService.createItem(
             user2.id,
             ItemCreateRequest(
-                categoryId = car.id,
+                categoryId = car.id!!,
                 name = "엔진오일",
                 imgUrl = "https://example.com/engineoil.png",
                 image = null,
@@ -107,7 +107,7 @@ class BaseInitData(
         itemService.createItem(
             user1.id,
             ItemCreateRequest(
-                categoryId = bathroom.id,
+                categoryId = bathroom.id!!,
                 name = "테스트용 칫솔 (D-Day 0)",
                 imgUrl = "https://example.com/test-toothbrush.png",
                 image = null,


### PR DESCRIPTION
<!--
PR 제목은 이슈와 동일하게 "키워드: 작업 내용"으로 등록해 주세요!
-->

## #️⃣연관된 이슈

close #66 

## 📝작업 내용

- BaseInitData의 ItemCreateRequest categoryId 타입 불일치 오류 해결