### PR TITLE
Refactor: [BACK] ReplacementEmailContent convert to Kotlin

### DIFF
--- a/backend/src/main/java/com/back/domain/email/dto/ReplacementEmailContent.kt
+++ b/backend/src/main/java/com/back/domain/email/dto/ReplacementEmailContent.kt
@@ -10,6 +10,7 @@ data class ReplacementEmailContent(
     val nextReplacementDate: LocalDate?
 ) {
 
+    // TODO: Item 도메인 Kotlin 전환 후 nullability 정리와 함께 String.format -> 문자열 템플릿으로 전환
     fun toHtmlContent(): String {
         return String.format(
             """

--- a/backend/src/main/java/com/back/domain/email/dto/ReplacementEmailContent.kt
+++ b/backend/src/main/java/com/back/domain/email/dto/ReplacementEmailContent.kt
@@ -1,30 +1,18 @@
-package com.back.domain.email.dto;
+package com.back.domain.email.dto
 
-import com.back.domain.item.item.entity.Item;
-import lombok.Builder;
-import lombok.Getter;
+import com.back.domain.item.item.entity.Item
+import java.time.LocalDate
 
-import java.time.LocalDate;
+data class ReplacementEmailContent(
+    val itemName: String?, //TODO: Item이 Kotlin 프로퍼티가 아니라서 null 허용, Item이 Kotlin으로 리팩토링되면 null 허용 제거
+    val startDate: LocalDate?,
+    val cycleDays: String?,
+    val nextReplacementDate: LocalDate?
+) {
 
-@Getter
-@Builder
-public class ReplacementEmailContent {
-    private String itemName;
-    private LocalDate startDate;
-    private String cycleDays;
-    private LocalDate nextReplacementDate;
-
-    public static ReplacementEmailContent from(Item item) {
-        return ReplacementEmailContent.builder()
-                .itemName(item.getName())
-                .startDate(item.getStartDate())
-                .cycleDays(item.getCycleDays())
-                .nextReplacementDate(item.getNextReplacementDate())
-                .build();
-    }
-
-    public String toHtmlContent() {
-        return String.format("""
+    fun toHtmlContent(): String {
+        return String.format(
+            """
                         <!DOCTYPE html>
                         <html>
                         <head>
@@ -65,15 +53,23 @@ public class ReplacementEmailContent {
                             </div>
                         </body>
                         </html>
-                        """,
-                itemName,
-                startDate,
-                cycleDays,
-                nextReplacementDate
-        );
+                        
+                        """.trimIndent(),
+            itemName,
+            startDate,
+            cycleDays,
+            nextReplacementDate
+        )
     }
 
-    public String getEmailSubject() {
-        return "[교체 알림] " + itemName + " 교체 시기입니다!";
+    companion object {
+        fun from(item: Item): ReplacementEmailContent {
+            return ReplacementEmailContent(
+                itemName = item.name,
+                startDate = item.startDate,
+                cycleDays = item.cycleDays,
+                nextReplacementDate = item.nextReplacementDate
+            )
+        }
     }
 }


### PR DESCRIPTION
#️⃣연관된 이슈

close #57

## 작업 내용

기존 Java + Lombok으로 작성된 `ReplacementEmailContent`를 Kotlin으로 전환했습니다.  
DTO 생성 로직은 유지하면서 Lombok 의존을 제거하고, Kotlin의 `data class`/`companion object` 기반으로 정리했습니다.

---

## 주요 변경 사항

### 1) DTO 구조 전환 (`@Getter/@Builder` 제거)

수정 전 (Java)
```java
@Getter
@Builder
public class ReplacementEmailContent {
    private String itemName;
    private LocalDate startDate;
    private String cycleDays;
    private LocalDate nextReplacementDate;
}
```

수정 후 (Kotlin)
```kotlin
data class ReplacementEmailContent(
    val itemName: String?,
    val startDate: LocalDate?,
    val cycleDays: String?,
    val nextReplacementDate: LocalDate?
)
```

설명:
- Lombok 어노테이션 제거
- Kotlin 프로퍼티 기반 DTO로 변경

### 2) 객체 생성 방식 전환 (Builder -> 생성자)

수정 전 (Java)
```java
return ReplacementEmailContent.builder()
        .itemName(item.getName())
        .startDate(item.getStartDate())
        .cycleDays(item.getCycleDays())
        .nextReplacementDate(item.getNextReplacementDate())
        .build();
```

수정 후 (Kotlin)
```kotlin
return ReplacementEmailContent(
    itemName = item.name,
    startDate = item.startDate,
    cycleDays = item.cycleDays,
    nextReplacementDate = item.nextReplacementDate
)
```

설명:
- `builder()` 체인 제거
- named argument 생성자 호출로 단순화

### 3) 정적 팩토리 메서드 전환 (`static` -> `companion object`)

수정 전 (Java)
```java
public static ReplacementEmailContent from(Item item) { ... }
```

수정 후 (Kotlin)
```kotlin
companion object {
    fun from(item: Item): ReplacementEmailContent { ... }
}
```

설명:
- Java의 `static` 패턴을 Kotlin `companion object`로 치환

### 4) 미사용 코드 정리

수정 전
```kotlin
val emailSubject: String
    get() = "[교체 알림] " + itemName + " 교체 시기입니다!"
```

수정 후
```kotlin
// 제거됨
```

설명:
- 실제 사용처가 없는 `emailSubject` 프로퍼티 제거

### 5) HTML 생성 로직 유지

수정 전 (Java)
```java
public String toHtmlContent() {
    return String.format("""...""", itemName, startDate, cycleDays, nextReplacementDate);
}
```

수정 후 (Kotlin)
```kotlin
fun toHtmlContent(): String {
    return String.format(
        """...""".trimIndent(),
        itemName, startDate, cycleDays, nextReplacementDate
    )
}
```

설명:
- 출력 템플릿 구조/포맷은 유지
- Kotlin 멀티라인 문자열 스타일로 정리

---

## 테스트

- 실행 시도:
  - `./gradlew compileKotlin`
  - `./gradlew test --tests "com.back.domain.email.*"`
- 결과:
  - 현재 브랜치의 `BaseInitData.kt`(73~110 라인대)에서 `Long? -> Long` 타입 불일치로 `compileKotlin` 단계 실패
  - `ReplacementEmailContent` 변경 자체와 별개인 기존 브랜치 컴파일 이슈 확인
