### PR TITLE
Refactor: [BACK]UserController Convert

### DIFF
--- a/backend/src/main/java/com/back/domain/user/user/controller/ApiV1UserController.kt
+++ b/backend/src/main/java/com/back/domain/user/user/controller/ApiV1UserController.kt
@@ -65,8 +65,7 @@ class ApiV1UserController(
     @DeleteMapping("/me")
     @Operation(summary = "탈퇴")
     fun deleteMe(): RsData<UserDto> {
-        val actor = rq.actor
-            ?: throw ServiceException(ErrorCode.LOGIN_REQUIRED)
+        val actor = rq.requireActor()
 
         userService.deleteById(actor.id)
         rq.setCookie("accessToken", "")
@@ -81,8 +80,7 @@ class ApiV1UserController(
     @GetMapping("/me")
     @Operation(summary = "내 정보 조회")
     fun me(): RsData<UserDto> {
-        val actor = rq.actor
-            ?: throw ServiceException(ErrorCode.LOGIN_REQUIRED)
+        val actor = rq.requireActor()
 
         // UserDto는 이미 필요한 정보를 포함하고 있으므로 그대로 반환
         return RsData(
@@ -109,8 +107,7 @@ class ApiV1UserController(
     fun updateProfile(
         @Valid @RequestBody request: UserProfileUpdateRequest
     ): RsData<UserUpdateResponse> {
-        val actor = rq.actor
-            ?: throw ServiceException(ErrorCode.LOGIN_REQUIRED)
+        val actor = rq.requireActor()
 
         val updatedUser = userService.updateProfile(actor.id, request.email)
 
@@ -131,8 +128,7 @@ class ApiV1UserController(
     fun changePassword(
         @Valid @RequestBody request: PasswordChangeRequest
     ): RsData<UserUpdateResponse> {
-        val actor = rq.actor
-            ?: throw ServiceException(ErrorCode.LOGIN_REQUIRED)
+        val actor = rq.requireActor()
 
         val updatedUser = userService.changePassword(
             actor.id,
@@ -157,8 +153,7 @@ class ApiV1UserController(
     fun verifyPassword(
         @Valid  @RequestBody request: PasswordVerifyRequest
     ): RsData<Void> {
-        val actor = rq.actor
-            ?: throw ServiceException(ErrorCode.LOGIN_REQUIRED)
+        val actor = rq.requireActor()
 
         val user = userService.findById(actor.id)
             ?: throw ServiceException(ErrorCode.USER_NOT_FOUND)

--- a/backend/src/main/java/com/back/domain/user/user/controller/ApiV1UserController.kt
+++ b/backend/src/main/java/com/back/domain/user/user/controller/ApiV1UserController.kt
@@ -1,7 +1,6 @@
 package com.back.domain.user.user.controller
 
 import com.back.domain.user.user.dto.*
-import com.back.domain.user.user.dto.UserLoginResponse.Companion.of
 import com.back.domain.user.user.service.UserService
 import com.back.global.exception.ErrorCode
 import com.back.global.exception.ServiceException
@@ -10,7 +9,6 @@ import com.back.global.rsData.RsData
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
-import lombok.RequiredArgsConstructor
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.*
 
@@ -72,7 +70,7 @@ class ApiV1UserController(
         val actor = rq.actor
             ?: throw ServiceException(ErrorCode.LOGIN_REQUIRED)
 
-        userService.deleteById(actor.id!!)
+        userService.deleteById(actor.id)
         rq.setCookie("accessToken", "")
 
         return RsData(

--- a/backend/src/main/java/com/back/domain/user/user/controller/ApiV1UserController.kt
+++ b/backend/src/main/java/com/back/domain/user/user/controller/ApiV1UserController.kt
@@ -79,16 +79,14 @@ class ApiV1UserController(
 
     @GetMapping("/me")
     @Operation(summary = "내 정보 조회")
-    fun me(): RsData<UserDto> {
-        val actor = rq.requireActor()
-
-        // UserDto는 이미 필요한 정보를 포함하고 있으므로 그대로 반환
-        return RsData(
-            "200-1",
-            "${actor.loginId}님의 정보입니다.",
-            actor
-        )
-    }
+    fun me(): RsData<UserDto> =
+        rq.requireActor().let { actor ->
+            RsData(
+                "200-1",
+                "${actor.loginId}님의 정보입니다.",
+                actor
+            )
+        }
 
     @PostMapping("/logout")
     @Operation(summary = "로그아웃")

--- a/backend/src/main/java/com/back/domain/user/user/controller/ApiV1UserController.kt
+++ b/backend/src/main/java/com/back/domain/user/user/controller/ApiV1UserController.kt
@@ -21,7 +21,6 @@ class ApiV1UserController(
 ) {
 
     @PostMapping("/signup")
-    @Transactional
     @Operation(summary = "회원가입")
     fun join(@Valid @RequestBody request: UserJoinRequest): RsData<UserDto> {
         // BindingResult 제거 - GlobalExceptionHandler가 자동으로 처리
@@ -42,7 +41,6 @@ class ApiV1UserController(
     }
 
     @PostMapping("/login")
-    @Transactional(readOnly = true)
     @Operation(summary = "로그인")
     fun login(
         @Valid @RequestBody reqBody: UserLoginRequest

--- a/backend/src/main/java/com/back/domain/user/user/service/UserService.kt
+++ b/backend/src/main/java/com/back/domain/user/user/service/UserService.kt
@@ -5,10 +5,9 @@ import com.back.domain.user.user.repository.UserRepository
 import com.back.global.exception.ErrorCode
 import com.back.global.exception.ServiceException
 import com.back.global.s3.S3ImageService
-import jakarta.transaction.Transactional
+import org.springframework.transaction.annotation.Transactional
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
-import lombok.RequiredArgsConstructor
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import java.util.*
@@ -21,8 +20,10 @@ class UserService(
     private val s3ImageService: S3ImageService,
 ) {
 
+    @Transactional(readOnly = true)
     fun count(): Long = userRepository.count()
 
+    @Transactional
     fun join(loginId: String, password: String, email: String): User {
         if (userRepository.findByLoginId(loginId) != null) {
             throw ServiceException(ErrorCode.DUPLICATE_LOGIN_ID)
@@ -33,6 +34,7 @@ class UserService(
         return userRepository.save(user)
     }
 
+    @Transactional(readOnly = true)
     fun findByLoginId(loginId: String) = userRepository.findByLoginId(loginId)
 
 
@@ -51,16 +53,20 @@ class UserService(
         userRepository.deleteById(id)
     }
 
+    @Transactional
     fun checkPassword(user: User, password: String) {
         if (!passwordEncoder.matches(password, user.password)) {
             throw ServiceException(ErrorCode.INVALID_PASSWORD)
         }
     }
 
+    @Transactional(readOnly = true)
     fun findByApiKey(apiKey: String) = userRepository.findByApiKey(apiKey)
 
+    @Transactional
     fun genAccessToken(user: User): String = authTokenService.genAccessToken(user)
 
+    @Transactional(readOnly = true)
     fun findById(id: Long): User? =
         userRepository.findById(id).orElse(null)
 

--- a/backend/src/main/java/com/back/global/rq/Rq.kt
+++ b/backend/src/main/java/com/back/global/rq/Rq.kt
@@ -91,4 +91,7 @@ class Rq(
 
     val member: User?
         get() = userService.findById(memberId)
+
+    fun requireActor(): UserDto =
+        actor ?: throw ServiceException(ErrorCode.LOGIN_REQUIRED)
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #83 

## 📝 작업 내용

### ✅ ApiV1UserController Java → Kotlin 전환

- `ApiV1UserController`를 Kotlin으로 변환
- Lombok 제거 및 생성자 주입 방식으로 변경
- nullable 처리 및 Kotlin null-safety 적용
- `actor.id!!` 제거 (UserDto.id를 non-null로 정리)
- 문자열 포맷을 Kotlin 문자열 템플릿(`"${}"`) 방식으로 변경
- 불필요한 import 및 어노테이션 정리

---

### 🔹 주요 변경 사항

1. **Null 안정성 강화**
   - `rq.actor ?: throw ServiceException(...)` 형태로 안전 처리
   - `UserDto.id`를 `Long`(non-null)로 정리하여 `!!` 제거

2. **Kotlin 스타일 반영**
   - `String.format()` → `"${user.loginId}"` 형태로 변경
   - 생성자 주입 방식으로 전환 (Lombok 제거)
   - 불필요한 BindingResult 제거 (GlobalExceptionHandler 사용)

3. **기존 로직 유지**
   - 회원가입 / 로그인 / 로그아웃 / 탈퇴 / 프로필 수정 / 비밀번호 변경 로직은 기존과 동일
   - 쿠키 세팅 로직 유지
   - 토큰 재발급 로직 유지

---

## 💬 리뷰 요청사항
**이전 pr에 controller 전환한 commit이 같이 올라가서 files changed 말고 그냥 코드 전체로 읽어주시면 감사하겠습니다..**

- `UserLoginResponse.of(...)` 호출 방식은 유지한 상태입니다.
  (향후 DTO에서 `@JvmStatic` 제거 예정이지만 Kotlin에서는 companion object 함수 호출이 가능하므로 문제 없을 것으로 판단됩니다.)

- `UserDto.id`를 non-null로 변경한 방향이 적절한지 확인 부탁드립니다.
  (rq.actor는 로그인된 사용자이므로 id가 null일 수 없다고 판단)

---

## 🔎 테스트 체크 리스트

- 전체 테스트 통과 확인 (User / Item / Email / Controller / Service 포함)


---