### PR TITLE
Refactor: [BACK] EmailServiceTest/EmailControllerTest 테스트 리팩토링

### DIFF
--- a/backend/src/test/java/com/back/domain/email/controller/EmailControllerTest.kt
+++ b/backend/src/test/java/com/back/domain/email/controller/EmailControllerTest.kt
@@ -9,9 +9,10 @@ import com.back.domain.user.user.repository.UserRepository
 import com.back.domain.user.user.service.UserService
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.doReturn
-import org.mockito.Mockito.verify
-import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
@@ -24,6 +25,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPat
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
+
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -64,7 +66,7 @@ internal class EmailControllerTest {
         val itemId = item.id ?: error("item id is null")
 
         doReturn(itemUser.email)
-            .`when`(emailService)
+            .whenever(emailService)
             .sendDDayNotification(itemUser.email, item)
 
         mvc.perform(post("/api/v1/email/test/dday/{itemId}", itemId)

--- a/backend/src/test/java/com/back/domain/email/service/EmailServiceTest.kt
+++ b/backend/src/test/java/com/back/domain/email/service/EmailServiceTest.kt
@@ -16,10 +16,10 @@ import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.BDDMockito
 import org.mockito.InjectMocks
 import org.mockito.Mock
-import org.mockito.kotlin.any
 import org.mockito.junit.jupiter.MockitoExtension
 import org.springframework.mail.javamail.JavaMailSender
 import java.time.LocalDate
+import org.mockito.kotlin.*
 
 @ExtendWith(MockitoExtension::class) // Mockito 확장 사용 (Mock 객체 초기화)
 @DisplayName("EmailService 테스트")
@@ -65,17 +65,13 @@ internal class EmailServiceTest {
         recipientEmail = "test@example.com"
 
         // 테스트마다 MimeMessage 생성은 공통 스텁으로 고정
-        BDDMockito.given(javaMailSender.createMimeMessage())
-            .willAnswer { MimeMessage(null as Session?) }
+        whenever(javaMailSender.createMimeMessage())
+            .thenAnswer { MimeMessage(null as Session?) }
     }
 
     @Test
     @DisplayName("이메일 발송 성공 테스트")
     fun sendDDayNotification_Success() {
-        // 메일 전송 시 예외 없이 정상 동작하도록 설정
-        BDDMockito.willDoNothing().given(javaMailSender)
-            .send(any<MimeMessage>())
-
         // D-Day 알림 메일 발송
         val result = emailService.sendDDayNotification(recipientEmail, testItem)
 
@@ -83,8 +79,8 @@ internal class EmailServiceTest {
         Assertions.assertThat(result).isEqualTo(recipientEmail)
 
         // 메일 생성 및 전송이 각각 1번씩 호출되었는지 검증
-        BDDMockito.then(javaMailSender).should(BDDMockito.times(1)).createMimeMessage()
-        BDDMockito.then(javaMailSender).should(BDDMockito.times(1))
+        verify(javaMailSender, times(1)).createMimeMessage()
+        verify(javaMailSender, times(1))
             .send(any<MimeMessage>())
     }
 
@@ -106,8 +102,8 @@ internal class EmailServiceTest {
             .hasMessageContaining("메일 발송 실패")
 
         // 메일 생성 및 전송 시도가 있었는지 검증
-        BDDMockito.then(javaMailSender).should(BDDMockito.times(1)).createMimeMessage()
-        BDDMockito.then(javaMailSender).should(BDDMockito.times(1))
+        verify(javaMailSender, times(1)).createMimeMessage()
+        verify(javaMailSender, times(1))
             .send(any<MimeMessage>())
     }
 
@@ -126,10 +122,6 @@ internal class EmailServiceTest {
             true
         )
 
-        // 메일 전송 정상 설정
-        BDDMockito.willDoNothing().given(javaMailSender)
-            .send(any<MimeMessage>())
-
         // 다른 수신자 + 다른 아이템으로 메일 발송
         val result = emailService.sendDDayNotification("another@example.com", differentItem)
 
@@ -137,8 +129,8 @@ internal class EmailServiceTest {
         Assertions.assertThat(result).isEqualTo("another@example.com")
 
         // 메일 생성 및 전송이 1회 호출되었는지 검증
-        BDDMockito.then(javaMailSender).should(BDDMockito.times(1)).createMimeMessage()
-        BDDMockito.then(javaMailSender).should(BDDMockito.times(1))
+        verify(javaMailSender, times(1)).createMimeMessage()
+        verify(javaMailSender, times(1))
             .send(any<MimeMessage>())
     }
 
@@ -152,14 +144,11 @@ internal class EmailServiceTest {
     )
     @DisplayName("여러 수신자에게 이메일 발송 테스트")
     fun sendDDayNotification_MultipleRecipients(email: String) {
-        BDDMockito.willDoNothing().given(javaMailSender)
-            .send(any<MimeMessage>())
-
         val result = emailService.sendDDayNotification(email, testItem)
 
         Assertions.assertThat(result).isEqualTo(email)
-        BDDMockito.then(javaMailSender).should(BDDMockito.times(1)).createMimeMessage()
-        BDDMockito.then(javaMailSender).should(BDDMockito.times(1)).send(any<MimeMessage>())
+        verify(javaMailSender, times(1)).createMimeMessage()
+        verify(javaMailSender, times(1)).send(any<MimeMessage>())
     }
 
     @Test
@@ -201,10 +190,6 @@ internal class EmailServiceTest {
         // 교체 알림이 필요한 아이템 리스트
         val items = arrayOf(item1, item2, item3)
 
-        // 메일 전송 정상 설정
-        BDDMockito.willDoNothing().given(javaMailSender)
-            .send(any<MimeMessage>())
-
         // 동일한 수신자에게 여러 아이템에 대한 메일 발송
         for (item in items) {
             val result = emailService.sendDDayNotification(recipientEmail, item)
@@ -214,8 +199,8 @@ internal class EmailServiceTest {
         }
 
         // 아이템 개수만큼 메일 생성/전송이 호출되었는지 검증
-        BDDMockito.then(javaMailSender).should(BDDMockito.times(3)).createMimeMessage()
-        BDDMockito.then(javaMailSender).should(BDDMockito.times(3))
+        verify(javaMailSender, times(3)).createMimeMessage()
+        verify(javaMailSender, times(3))
             .send(any<MimeMessage>())
     }
 }


### PR DESCRIPTION
#️⃣연관된 이슈

refs #109

## 작업 내용

이번 작업은 테스트 리팩토링 범위에서 `EmailControllerTest.kt`와 `EmailServiceTest.kt`를 Kotlin 스타일로 정리한 내용입니다.  
핵심은 Mockito 문법 일관화, nullable 안정성 강화, 불필요 stubbing 제거입니다.  
이번 PR 범위 밖: 프로덕션 이메일 도메인 로직 변경, API 스펙 변경.

---

## 주요 변경 사항

### 1) EmailControllerTest Mockito 사용 방식 정리 (`doReturn().when` → Kotlin DSL `doReturn().whenever`)

수정 전 (Java)
```java
given(emailService.sendDDayNotification(eq(item.getUser().getEmail()), eq(item)))
        .willReturn(item.getUser().getEmail());
```

수정 후 1 (IntelliJ Convert)
```kotlin
doReturn(itemUser.email)
    .`when`(emailService)
    .sendDDayNotification(itemUser.email, item)
```

수정 후 2 (Kotlin Final)
```kotlin
doReturn(itemUser.email)
    .whenever(emailService)
    .sendDDayNotification(itemUser.email, item)
```

설명  
Kotlin에서 `whenever`를 쓰면 백틱 기반 `when` 호출보다 가독성이 좋아지고, matcher/NPE 이슈를 줄이기 쉽습니다.

---

### 2) EmailServiceTest stubbing 최소화 (`doNothing` 제거, 필요한 예외 stubbing만 유지)

수정 전 (Java)
```java
doNothing().when(javaMailSender).send(any(MimeMessage.class));
```

수정 후 1 (IntelliJ Convert)
```kotlin
Mockito.doNothing().`when`(javaMailSender)
    .send(any<MimeMessage>())
```

수정 후 2 (Kotlin Final)
```kotlin
// 성공 케이스는 doNothing 생략
verify(javaMailSender, times(1)).send(any<MimeMessage>())

// 실패 케이스만 명시적 stubbing 유지
BDDMockito.willThrow(RuntimeException("메일 서버 오류"))
    .given(javaMailSender).send(any<MimeMessage>())
```

설명  
`void` 메서드의 기본 동작은 no-op이므로 성공 케이스 `doNothing`은 중복입니다. 실패 시나리오만 예외 stubbing을 남겨 테스트 목적이 선명해졌습니다.

---

### 3) EmailServiceTest Kotlin DSL 통일 (Mockito static 스타일 혼용 축소)

수정 전 (Java)
```java
verify(javaMailSender, times(1)).createMimeMessage();
verify(javaMailSender, times(1)).send(any(MimeMessage.class));
```

수정 후 1 (IntelliJ Convert)
```kotlin
Mockito.verify(javaMailSender, Mockito.times(1)).createMimeMessage()
Mockito.verify(javaMailSender, Mockito.times(1))
    .send(any<MimeMessage>())
```

수정 후 2 (Kotlin Final)
```kotlin
verify(javaMailSender, times(1)).createMimeMessage()
verify(javaMailSender, times(1)).send(any<MimeMessage>())
```

설명  
`org.mockito.kotlin.*` 기반으로 통일해 문법 혼용을 줄였고, Kotlin 테스트 코드 가독성과 유지보수성을 높였습니다.

---

## Public API / Interface 변경

없음.  
테스트 코드 리팩토링만 수행했으며 런타임 API/엔드포인트/DTO 스키마 변경은 없습니다.

---

## 테스트/검증

실행:
- back.test

결과:
- BUILD SUCCESSFUL

시나리오 체크리스트
1. 정상 시나리오: 성공 응답/반환값/호출 횟수 검증 유지
2. 실패 시나리오: 예외 메시지 및 상태 코드 검증 유지
3. 미호출 시나리오: `verifyNoInteractions(emailService)`로 명확화
4. Kotlin matcher 안정성: `any/eq` 혼용 리스크 구간을 Kotlin DSL 중심으로 정리

---

## 커밋/PR 메타

브랜치  
`refactor/be/emailservicetest-emailcontrollertest-test-refactoring/109`

리뷰 포인트
1. `EmailControllerTest`의 `verifyNoInteractions`가 팀 검증 의도와 일치하는지
2. `EmailServiceTest` 성공 케이스에서 `doNothing` 제거가 팀 컨벤션과 맞는지
3. BDD(`willThrow`)와 Kotlin DSL(`verify/whenever`) 혼용 기준을 팀 규칙으로 고정할지

