### PR TITLE
refactor: ItemRepository findByIdAndUserId 반환형 변경 (Optional -> Item?)

### DIFF
--- a/backend/src/main/java/com/back/domain/item/item/repository/ItemRepository.kt
+++ b/backend/src/main/java/com/back/domain/item/item/repository/ItemRepository.kt
@@ -12,8 +12,7 @@ interface ItemRepository : JpaRepository<Item, Long> {
     fun findAllByUserIdOrderByNextReplacementDateAsc(userId: Long): List<Item>
 
     // 단건조회
-    //TODO Item Service 코틀린전환후 Optional 객체로 감쌀 필요 없이 그냥 Item?을 반환하도록 변경
-    fun findByIdAndUserId(id: Long, userId: Long): Optional<Item>
+    fun findByIdAndUserId(id: Long, userId: Long): Item?
 
     // 카테고리별목록조회
     fun findAllByUserIdAndCategoryId(userId: Long, categoryId: Long): List<Item>

--- a/backend/src/main/java/com/back/domain/item/item/service/ItemService.kt
+++ b/backend/src/main/java/com/back/domain/item/item/service/ItemService.kt
@@ -57,7 +57,7 @@ class ItemService(
     // itemId + userId로 Item 조회 및 권한 검증 (쿼리 1회로 최적화)
     private fun findOwnedItemOrThrow(itemId: Long, userId: Long): Item {
         return itemRepository.findByIdAndUserId(itemId, userId)
-            .orElseThrow { ServiceException(ErrorCode.ITEM_NOT_FOUND_OR_NO_PERMISSION) }
+            ?: throw ServiceException(ErrorCode.ITEM_NOT_FOUND_OR_NO_PERMISSION)
     }
 
     // userId로 User 조회

--- a/backend/src/main/java/com/back/domain/item/itemHistory/service/ItemHistoryService.kt
+++ b/backend/src/main/java/com/back/domain/item/itemHistory/service/ItemHistoryService.kt
@@ -27,7 +27,7 @@ class ItemHistoryService(
     @Transactional(readOnly = true)
     fun getItemHistories(itemId: Long, userId: Long): List<ItemHistoryResponse> {
         itemRepository.findByIdAndUserId(itemId, userId)
-            .orElseThrow { ServiceException(ErrorCode.ITEM_NOT_FOUND_OR_NO_PERMISSION) }
+            ?: throw ServiceException(ErrorCode.ITEM_NOT_FOUND_OR_NO_PERMISSION)
 
         val histories = itemHistoryRepository.findByItemIdOrderByStartDateDesc(itemId)
         return ItemHistoryResponse.fromList(histories)

--- a/backend/src/test/java/com/back/domain/item/item/service/ItemServiceTest.kt
+++ b/backend/src/test/java/com/back/domain/item/item/service/ItemServiceTest.kt
@@ -128,8 +128,7 @@ internal class ItemServiceTest {
     @Test
     @DisplayName("아이템 ID와 사용자 ID로 조회 성공")
     fun findByIdAndUserId_Success() {
-        given(itemRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(testItem))
-
+        given(itemRepository.findByIdAndUserId(1L, 1L)).willReturn(testItem)
         val result = itemService.findByIdAndUserId(1L, 1L)
 
         assertThat(result.name).isEqualTo("칫솔")
@@ -139,8 +138,7 @@ internal class ItemServiceTest {
     @Test
     @DisplayName("아이템 ID와 사용자 ID로 조회 실패 - 권한 없음")
     fun findByIdAndUserId_Failure_NoPermission() {
-        given(itemRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.empty())
-
+        given(itemRepository.findByIdAndUserId(1L, 1L)).willReturn(null)
         assertThatThrownBy { itemService.findByIdAndUserId(1L, 1L) }
             .isInstanceOf(ServiceException::class.java)
             .hasMessageContaining(ErrorCode.ITEM_NOT_FOUND_OR_NO_PERMISSION.message)
@@ -237,7 +235,7 @@ internal class ItemServiceTest {
     @Test
     @DisplayName("아이템 수정 성공")
     fun modify_Success() {
-        given(itemRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(testItem))
+        given(itemRepository.findByIdAndUserId(1L, 1L)).willReturn(testItem)
         given(categoryRepository.findById(1L)).willReturn(Optional.of(testCategory))
         doNothing().`when`(s3ImageService).delete(anyString())
 
@@ -250,7 +248,7 @@ internal class ItemServiceTest {
     @Test
     @DisplayName("아이템 수정 실패 - 권한 없음")
     fun modify_Failure_NoPermission() {
-        given(itemRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.empty())
+        given(itemRepository.findByIdAndUserId(1L, 1L)).willReturn(null)
 
         assertThatThrownBy { itemService.modify(1L, 1L, updateRequest) }
             .isInstanceOf(ServiceException::class.java)
@@ -260,7 +258,7 @@ internal class ItemServiceTest {
     @Test
     @DisplayName("아이템 교체 성공")
     fun replaceItem_Success() {
-        given(itemRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(testItem))
+        given(itemRepository.findByIdAndUserId(1L, 1L)).willReturn(testItem)
 
         // safeAny를 사용했던 부분들을 모두 mockito-kotlin의 any()로 변경
         doNothing().`when`(itemHistoryService).endHistory(anyLong(), any())
@@ -282,7 +280,7 @@ internal class ItemServiceTest {
             LocalDate.of(2024, 1, 1), "90d", LocalDate.of(2024, 4, 1), false
         )
 
-        given(itemRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(inactiveItem))
+        given(itemRepository.findByIdAndUserId(1L, 1L)).willReturn(inactiveItem)
 
         assertThatThrownBy { itemService.replaceItem(1L, 1L) }
             .isInstanceOf(ServiceException::class.java)
@@ -293,7 +291,7 @@ internal class ItemServiceTest {
     @Test
     @DisplayName("아이템 활성화 토글 성공")
     fun toggleActive_Success() {
-        given(itemRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(testItem))
+        given(itemRepository.findByIdAndUserId(1L, 1L)).willReturn(testItem)
 
         val result = itemService.toggleActive(1L, 1L)
 
@@ -304,7 +302,7 @@ internal class ItemServiceTest {
     @Test
     @DisplayName("아이템 삭제 성공")
     fun deleteItem_Success() {
-        given(itemRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(testItem))
+        given(itemRepository.findByIdAndUserId(1L, 1L)).willReturn(testItem)
 
         // safeAny(Item::class.java) 대신 mockito-kotlin의 any() 적용
         doNothing().`when`(itemRepository).delete(any())
@@ -317,7 +315,7 @@ internal class ItemServiceTest {
     @Test
     @DisplayName("아이템 삭제 실패 - 권한 없음")
     fun deleteItem_Failure_NoPermission() {
-        given(itemRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.empty())
+        given(itemRepository.findByIdAndUserId(1L, 1L)).willReturn(null)
 
         assertThatThrownBy { itemService.deleteItem(1L, 1L) }
             .isInstanceOf(ServiceException::class.java)


### PR DESCRIPTION
## #️⃣연관된 이슈

close #127 

---

## 작업 내용
- 기존 `ItemRepository`의 단건 조회 메서드(`findByIdAndUserId`)가 Java의 `Optional<Item>`을 반환
- 이를 Kotlin의 Null 안전성(Null Safety) 문법에 맞게 `Item?` (Nullable) 타입으로 변경하여, 코드를 더 간결하고 Kotlin의 관용적인(Idiomatic) 스타일로 개선

## 주요 변경 사항
- **`ItemRepository.kt`**: `findByIdAndUserId` 반환형을 `Optional<Item>` -> `Item?`로 수정
- **`ItemService.kt` / `ItemHistoryService.kt`**: 
  - `Optional.orElseThrow()` 메서드 체이닝을 제거하고, 엘비스 연산자(`?:`)를 사용하여 `null`일 경우 예외를 던지도록 서비스 로직 간소화
- **`ItemServiceTest.kt`**: 
  - 타입 변경에 따라 발생한 테스트 코드 컴파일 에러(Argument type mismatch) 해결
  - Mockito 스터빙(`given`) 시 `Optional.of()`와 `Optional.empty()`로 래핑하던 부분을 실제 엔티티 객체와 `null`을 직접 반환하도록 전면 수정