### PR TITLE
Refactor: [BACK] domain.email TODO 정리 및 null-safe 강화

### DIFF
--- a/backend/src/main/java/com/back/domain/email/controller/EmailController.kt
+++ b/backend/src/main/java/com/back/domain/email/controller/EmailController.kt
@@ -29,8 +29,11 @@ class EmailController (
             // 아이템에 연결된 사용자 조회 // 사용자 미연결 방어
             val user = item.user ?: throw ServiceException(ErrorCode.DATA_NOT_FOUND, "아이템에 연결된 사용자가 없습니다.")
 
-            val email = user.email?.takeIf { it.isNotBlank() }
+            val email = user.email.takeIf { it.isNotBlank() }
                 ?: throw ServiceException(ErrorCode.INVALID_INPUT_VALUE, "사용자의 이메일 주소가 없습니다.")
+
+            val itemName = item.name?.takeIf { it.isNotBlank() }
+                ?: throw ServiceException(ErrorCode.DATA_NOT_FOUND, "아이템 이름이 없습니다.")
 
             // D-Day 알림 이메일 발송
             val sentToEmail = emailService.sendDDayNotification(email, item)
@@ -40,7 +43,7 @@ class EmailController (
             response["message"] = "테스트 D-Day 이메일 발송 성공"
             response["recipientEmail"] = sentToEmail
             response["itemId"] = itemId
-            response["itemName"] = item.name ?: ""
+            response["itemName"] = itemName
             response["userId"] = user.id
             response["userLoginId"] = user.loginId
 

--- a/backend/src/main/java/com/back/domain/email/dto/ReplacementEmailContent.kt
+++ b/backend/src/main/java/com/back/domain/email/dto/ReplacementEmailContent.kt
@@ -1,75 +1,67 @@
 package com.back.domain.email.dto
 
 import com.back.domain.item.item.entity.Item
+import com.back.global.exception.ErrorCode
+import com.back.global.exception.ServiceException
 import java.time.LocalDate
 
 data class ReplacementEmailContent(
-    val itemName: String?, //TODO: Item이 Kotlin 프로퍼티가 아니라서 null 허용, Item이 Kotlin으로 리팩토링되면 null 허용 제거
-    val startDate: LocalDate?,
-    val cycleDays: String?,
-    val nextReplacementDate: LocalDate?
+    val itemName: String,
+    val startDate: LocalDate,
+    val cycleDays: String,
+    val nextReplacementDate: LocalDate
 ) {
 
-    // TODO: Item 도메인 Kotlin 전환 후 nullability 정리와 함께 String.format -> 문자열 템플릿으로 전환
-    fun toHtmlContent(): String {
-        return String.format(
-            """
-                        <!DOCTYPE html>
-                        <html>
-                        <head>
-                            <style>
-                                body { font-family: Arial, sans-serif; }
-                                .container { margin: 50px; padding: 20px; }
-                                .header { background-color: #4CAF50; color: white; padding: 15px; border-radius: 5px; }
-                                .content { margin-top: 20px; padding: 20px; border: 1px solid #ddd; border-radius: 5px; }
-                                .item-info { background-color: #f9f9f9; padding: 15px; margin: 10px 0; border-radius: 5px; }
-                                .footer { margin-top: 20px; color: #666; font-size: 12px; }
-                            </style>
-                        </head>
-                        <body>
-                            <div class="container">
-                                <div class="header">
-                                    <h2>🔔 교체 알림</h2>
-                                </div>
-                        
-                                <div class="content">
-                                    <p>안녕하세요!</p>
-                                    <p>등록하신 아이템의 교체 시기가 되었습니다.</p>
-                        
-                                    <div class="item-info">
-                                        <h3>📦 아이템 정보</h3>
-                                        <p><strong>아이템 이름:</strong> %s</p>
-                                        <p><strong>시작일:</strong> %s</p>
-                                        <p><strong>교체 주기:</strong> %s</p>
-                                        <p><strong>교체 예정일:</strong> %s</p>
-                                        <p><strong>D-Day:</strong> <span style="color: red; font-weight: bold;">오늘!</span></p>
-                                    </div>
-                        
-                                    <p>아이템을 교체하신 후 앱에서 교체 완료 처리를 해주세요.</p>
-                                </div>
-                        
-                                <div class="footer">
-                                    <p>본 메일은 자동으로 발송되었습니다.</p>
-                                </div>
-                            </div>
-                        </body>
-                        </html>
-                        
-                        """.trimIndent(),
-            itemName,
-            startDate,
-            cycleDays,
-            nextReplacementDate
-        )
-    }
+    fun toHtmlContent(): String = """
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <style>
+                body { font-family: Arial, sans-serif; }
+                .container { margin: 50px; padding: 20px; }
+                .header { background-color: #4CAF50; color: white; padding: 15px; border-radius: 5px; }
+                .content { margin-top: 20px; padding: 20px; border: 1px solid #ddd; border-radius: 5px; }
+                .item-info { background-color: #f9f9f9; padding: 15px; margin: 10px 0; border-radius: 5px; }
+                .footer { margin-top: 20px; color: #666; font-size: 12px; }
+            </style>
+        </head>
+        <body>
+            <div class="container">
+                <div class="header">
+                    <h2>🔔 교체 알림</h2>
+                </div>
+
+                <div class="content">
+                    <p>안녕하세요!</p>
+                    <p>등록하신 아이템의 교체 시기가 되었습니다.</p>
+
+                    <div class="item-info">
+                        <h3>📦 아이템 정보</h3>
+                        <p><strong>아이템 이름:</strong> $itemName</p>
+                        <p><strong>시작일:</strong> $startDate</p>
+                        <p><strong>교체 주기:</strong> $cycleDays</p>
+                        <p><strong>교체 예정일:</strong> $nextReplacementDate</p>
+                        <p><strong>D-Day:</strong> <span style="color: red; font-weight: bold;">오늘!</span></p>
+                    </div>
+
+                    <p>아이템을 교체하신 후 앱에서 교체 완료 처리를 해주세요.</p>
+                </div>
+
+                <div class="footer">
+                    <p>본 메일은 자동으로 발송되었습니다.</p>
+                </div>
+            </div>
+        </body>
+        </html>
+    """.trimIndent()
 
     companion object {
         fun from(item: Item): ReplacementEmailContent {
             return ReplacementEmailContent(
-                itemName = item.name,
-                startDate = item.startDate,
-                cycleDays = item.cycleDays,
-                nextReplacementDate = item.nextReplacementDate
+                itemName = item.name ?: throw ServiceException(ErrorCode.DATA_NOT_FOUND, "아이템 이름이 없습니다."),
+                startDate = item.startDate ?: throw ServiceException(ErrorCode.DATA_NOT_FOUND, "아이템 시작일이 없습니다."),
+                cycleDays = item.cycleDays ?: throw ServiceException(ErrorCode.DATA_NOT_FOUND, "아이템 주기 정보가 없습니다."),
+                nextReplacementDate = item.nextReplacementDate ?: throw ServiceException(ErrorCode.DATA_NOT_FOUND, "아이템 교체 예정일이 없습니다.")
             )
         }
     }

--- a/backend/src/main/java/com/back/domain/email/scheduler/DdayEmailScheduler.kt
+++ b/backend/src/main/java/com/back/domain/email/scheduler/DdayEmailScheduler.kt
@@ -2,6 +2,8 @@ package com.back.domain.email.scheduler
 
 import com.back.domain.email.service.EmailService
 import com.back.domain.item.item.repository.ItemRepository
+import com.back.global.exception.ErrorCode
+import com.back.global.exception.ServiceException
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
@@ -28,8 +30,9 @@ class DdayEmailScheduler(
         val itemsDueToday = itemRepository.findAllByNextReplacementDateAndIsActive(today, true)
 
         for (item in itemsDueToday) {
-            val member = item.user // // 아이템과 연관된 사용자 조회
-            emailService.sendDDayNotification(member!!.email, item) // // D-Day 알림 이메일 발송
+            val member = item.user
+                ?: throw ServiceException(ErrorCode.DATA_NOT_FOUND, "아이템 사용자 정보가 없습니다. itemId=${item.id}")
+            emailService.sendDDayNotification(member.email, item)
         }
     }
 }

--- a/backend/src/main/java/com/back/domain/email/service/EmailService.kt
+++ b/backend/src/main/java/com/back/domain/email/service/EmailService.kt
@@ -23,12 +23,7 @@ class EmailService (
             mimeMessageHelper.setTo(recipientEmail)
 
             // 메일 제목
-            mimeMessageHelper.setSubject("[교체 알림] TODO추가부분 교체 시기입니다!")
-            //TODO: Item 엔티티가 Java+Lombok 상태라 Kotlin에서 프로퍼티/게터 참조 호환 이슈가 있음.
-            // item 도메인 Kotlin 전환 이후 `${item.name}` 형태로 정리 예정.
-            // `${item.getName()}` 형태도 불가능한 이유는 (여기는 Kotlin 코드이기 때문)
-            // Kotlin 컴파일 시점에 Java Lombok(@Getter) 생성 메서드를 해석하지 못해
-            // `Unresolved reference getName`가 발생함.
+            mimeMessageHelper.setSubject("[교체 알림] ${item.name} 교체 시기입니다!")
 
             // HTML 형식의 이메일 내용
             mimeMessageHelper.setText(emailContent.toHtmlContent(), true)


### PR DESCRIPTION
#️⃣연관된 이슈

refs #128

## 작업 내용

이번 브랜치에서는 `email` 도메인 후속 정리 작업을 진행했습니다.  
핵심은 null-safety 보강, `!!` 제거, TODO 제거(실제 코드 반영), 이메일 제목 하드코딩 해소입니다.  
이번 범위는 `domain.email` 영역만 대상으로 했고, 스케줄러/테스트 동작 의미는 유지했습니다.

---

## 주요 변경 사항

### 1) `EmailController`에서 `itemName` null-safety 보강

수정 전 (중간 Kotlin 상태)
```kotlin
response["itemName"] = item.name ?: ""
```

수정 후 (Kotlin Final)
```kotlin
val itemName = item.name?.takeIf { it.isNotBlank() }
    ?: throw ServiceException(ErrorCode.DATA_NOT_FOUND, "아이템 이름이 없습니다.")
response["itemName"] = itemName
```

설명
- 빈 문자열 fallback 대신 도메인 예외로 명시 처리
- `MutableMap<String, Any>` 타입 안정성 유지
- 오류 상황을 조기에 드러내도록 변경

---

### 2) `ReplacementEmailContent` DTO nullability 정리 + TODO 해소

수정 전 (중간 Kotlin 상태)
```kotlin
data class ReplacementEmailContent(
    val itemName: String?,
    val startDate: LocalDate?,
    val cycleDays: String?,
    val nextReplacementDate: LocalDate?
)
```

수정 후 (Kotlin Final)
```kotlin
data class ReplacementEmailContent(
    val itemName: String,
    val startDate: LocalDate,
    val cycleDays: String,
    val nextReplacementDate: LocalDate
)
```

설명
- DTO를 non-null로 고정
- nullable 엔티티 값은 `from(item)` 경계에서 `ServiceException(ErrorCode...)`로 검증
- TODO로 남아 있던 nullability 이슈를 코드로 반영 완료

---

### 3) `ReplacementEmailContent.toHtmlContent()` 문자열 템플릿 전환

수정 전 (중간 Kotlin 상태)
```kotlin
return String.format("""...%s...""".trimIndent(), itemName, startDate, cycleDays, nextReplacementDate)
```

수정 후 (Kotlin Final)
```kotlin
fun toHtmlContent(): String = """
...
<p><strong>아이템 이름:</strong> $itemName</p>
<p><strong>시작일:</strong> $startDate</p>
<p><strong>교체 주기:</strong> $cycleDays</p>
<p><strong>교체 예정일:</strong> $nextReplacementDate</p>
...
""".trimIndent()
```

설명
- `%s` 포맷 의존 제거
- Kotlin 템플릿으로 가독성 개선
- 관련 TODO 해소

---

### 4) `DdayEmailScheduler`의 `!!` 제거 + 예외 일관화

수정 전 (중간 Kotlin 상태)
```kotlin
val member = item.user
emailService.sendDDayNotification(member!!.email, item)
```

수정 후 (Kotlin Final)
```kotlin
val member = item.user
    ?: throw ServiceException(ErrorCode.DATA_NOT_FOUND, "아이템 사용자 정보가 없습니다. itemId=${item.id}")
emailService.sendDDayNotification(member.email, item)
```

설명
- `!!` 제거
- 글로벌 예외 처리 정책(`ServiceException + ErrorCode`)과 일관화

---

### 5) `EmailService` 제목 하드코딩/TODO 제거

수정 전 (중간 Kotlin 상태)
```kotlin
mimeMessageHelper.setSubject("[교체 알림] TODO추가부분 교체 시기입니다!")
```

수정 후 (Kotlin Final)
```kotlin
mimeMessageHelper.setSubject("[교체 알림] ${item.name} 교체 시기입니다!")
```

설명
- TODO placeholder 제거
- 실제 아이템 이름 반영

---

## Public API / Interface 변경

없음.  
런타임 API 엔드포인트/요청·응답 스키마 변경은 없습니다.

---

## 테스트/검증

실행:
- back.compileKotlin
- back.test (DdayEmailSchedulerTest)

결과:
- BUILD SUCCESSFUL

---

## 커밋/PR 메타

브랜치  
`refactor/be/domaincategoryemail-todo-및-후속-작업-정리/128`

리뷰 포인트
1. `ReplacementEmailContent.from()`의 null 검증 예외코드가 도메인 정책에 맞는지
2. Scheduler에서 사용자 null 시 `DATA_NOT_FOUND` 처리 기준이 운영 정책과 맞는지
3. `EmailController`의 `itemName` 빈 문자열 허용 대신 예외 처리로 바꾼 정책이 합의된 방향인지
