### PR TITLE
refactor: ErrorCode 중복 식별자 문제 해결 및 도메인 기반 네이밍 규칙 적용

### DIFF
--- a/backend/src/main/java/com/back/global/exception/ErrorCode.kt
+++ b/backend/src/main/java/com/back/global/exception/ErrorCode.kt
@@ -7,46 +7,62 @@ enum class ErrorCode(
     val message: String,
     val httpStatus: HttpStatus
 ) {
-    // 400 Bad Request
-    INVALID_INPUT_VALUE("400-1", "잘못된 입력값입니다.", HttpStatus.BAD_REQUEST),
-    INVALID_REQUEST_BODY("400-1", "요청 본문이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
-    SAME_PASSWORD("400-1", "새 비밀번호는 현재 비밀번호와 달라야 합니다.", HttpStatus.BAD_REQUEST),
-    INACTIVE_ITEM_CANNOT_REPLACE("400-2", "비활성 상태의 아이템은 교체할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    // RsData의 파싱 구조를 유지하면서도 에러 식별성을 높이기 위해
+    // code 포맷을 단순 숫자에서 '{HTTP상태코드}-{도메인접두사+일련번호}' 형태로 리팩토링
+    // 도메인 분류: C(Common/System), U(User/Auth), I(Item/Category), AI(Artificial Intelligence)
 
-    // 401 Unauthorized
-    LOGIN_REQUIRED("401-1", "로그인이 필요합니다.", HttpStatus.UNAUTHORIZED),
-    INVALID_LOGIN_ID("401-1", "존재하지 않는 아이디입니다.", HttpStatus.UNAUTHORIZED),
-    INVALID_PASSWORD("401-1", "비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
-    INVALID_AUTH_HEADER("401-2", "Authorization 헤더가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
-    INVALID_TOKEN_CLAIM("401-3", "토큰 클레임이 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
-    TOKEN_EXPIRED("401-4", "토큰이 만료되었습니다. 다시 로그인해주세요.", HttpStatus.UNAUTHORIZED),
-    INVALID_API_KEY("401-5", "API 키가 유효하지 않습니다.", HttpStatus.UNAUTHORIZED),
+    // --- 400 Bad Request ---
+    // 공통(C) 요청 오류
+    INVALID_INPUT_VALUE("400-C001", "잘못된 입력값입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_REQUEST_BODY("400-C002", "요청 본문이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+    // 유저(U) 관련 잘못된 요청
+    SAME_PASSWORD("400-U001", "새 비밀번호는 현재 비밀번호와 달라야 합니다.", HttpStatus.BAD_REQUEST),
+    // 아이템(I) 관련 잘못된 요청
+    INACTIVE_ITEM_CANNOT_REPLACE("400-I001", "비활성 상태의 아이템은 교체할 수 없습니다.", HttpStatus.BAD_REQUEST),
 
-    // 403 Forbidden
-    PASSWORD_MISMATCH("403-1", "현재 비밀번호가 일치하지 않습니다.", HttpStatus.FORBIDDEN),
-    NO_PERMISSION("403-1", "권한이 없습니다.", HttpStatus.FORBIDDEN),
+    // --- 401 Unauthorized ---
+    // 유저/인증(U) 오류 - 중복되던 401-1, 401-2 등의 코드를 U001~U007로 고유하게 분리
+    LOGIN_REQUIRED("401-U001", "로그인이 필요합니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_LOGIN_ID("401-U002", "존재하지 않는 아이디입니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_PASSWORD("401-U003", "비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_AUTH_HEADER("401-U004", "Authorization 헤더가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_TOKEN_CLAIM("401-U005", "토큰 클레임이 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
+    TOKEN_EXPIRED("401-U006", "토큰이 만료되었습니다. 다시 로그인해주세요.", HttpStatus.UNAUTHORIZED),
+    INVALID_API_KEY("401-U007", "API 키가 유효하지 않습니다.", HttpStatus.UNAUTHORIZED),
 
-    // 404 Not Found
-    ITEM_NOT_FOUND("404-1", "존재하지 않는 아이템입니다.", HttpStatus.NOT_FOUND),
-    ITEM_NOT_FOUND_OR_NO_PERMISSION("404-1", "존재하지 않는 아이템이거나 권한이 없습니다.", HttpStatus.NOT_FOUND),
-    USER_NOT_FOUND("404-1", "존재하지 않는 유저입니다.", HttpStatus.NOT_FOUND),
-    CATEGORY_NOT_FOUND("404-1", "존재하지 않는 카테고리입니다.", HttpStatus.NOT_FOUND),
-    DATA_NOT_FOUND("404-1", "해당 데이터가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
-    ONGOING_HISTORY_NOT_FOUND("404-1", "진행중인 이력이 없습니다.", HttpStatus.NOT_FOUND),
-    AI_ITEM_NOT_FOUND("404", "권장 주기를 찾을 수 없는 소모품입니다.", HttpStatus.NOT_FOUND),
+    // --- 403 Forbidden ---
+    // 유저/권한(U) 오류
+    PASSWORD_MISMATCH("403-U001", "현재 비밀번호가 일치하지 않습니다.", HttpStatus.FORBIDDEN),
+    NO_PERMISSION("403-U002", "권한이 없습니다.", HttpStatus.FORBIDDEN),
 
-    // 409 Conflict
-    DUPLICATE_LOGIN_ID("409-1", "이미 존재하는 아이디입니다.", HttpStatus.CONFLICT),
+    // --- 404 Not Found ---
+    // 공통(C) 조회 오류
+    DATA_NOT_FOUND("404-C001", "해당 데이터가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    // 아이템/카테고리(I) 조회 오류 - 중복되던 404-1 코드를 각각 고유 식별자로 분리
+    ITEM_NOT_FOUND("404-I001", "존재하지 않는 아이템입니다.", HttpStatus.NOT_FOUND),
+    ITEM_NOT_FOUND_OR_NO_PERMISSION("404-I002", "존재하지 않는 아이템이거나 권한이 없습니다.", HttpStatus.NOT_FOUND),
+    CATEGORY_NOT_FOUND("404-I003", "존재하지 않는 카테고리입니다.", HttpStatus.NOT_FOUND),
+    ONGOING_HISTORY_NOT_FOUND("404-I004", "진행중인 이력이 없습니다.", HttpStatus.NOT_FOUND),
+    // 유저(U) 조회 오류
+    USER_NOT_FOUND("404-U001", "존재하지 않는 유저입니다.", HttpStatus.NOT_FOUND),
+    // AI 도메인 조회 오류
+    AI_ITEM_NOT_FOUND("404-AI001", "권장 주기를 찾을 수 없는 소모품입니다.", HttpStatus.NOT_FOUND),
 
-    // 500 Internal Server Error
-    INTERNAL_SERVER_ERROR("500", "서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    IMAGE_UPLOAD_FAILED("500-1", "이미지 업로드 실패", HttpStatus.INTERNAL_SERVER_ERROR),
-    EMAIL_SEND_FAILED("500-1", "메일 발송 실패", HttpStatus.INTERNAL_SERVER_ERROR),
-    AI_TIMEOUT("500", "AI 응답 시간 초과", HttpStatus.INTERNAL_SERVER_ERROR),
-    AI_ERROR("500", "AI 처리 중 오류 발생", HttpStatus.INTERNAL_SERVER_ERROR),
-    AI_NO_RESPONSE("500", "AI로부터 응답을 받지 못했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    AI_INVALID_JSON("500", "AI 응답이 유효한 JSON 형식이 아닙니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    JSON_PARSING_ERROR("500", "JSON 파싱 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+    // --- 409 Conflict ---
+    // 유저(U) 충돌 오류
+    DUPLICATE_LOGIN_ID("409-U001", "이미 존재하는 아이디입니다.", HttpStatus.CONFLICT),
+
+    // --- 500 Internal Server Error ---
+    // 공통/시스템(C) 오류 - 중복되던 500, 500-1 코드를 세분화
+    INTERNAL_SERVER_ERROR("500-C001", "서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    IMAGE_UPLOAD_FAILED("500-C002", "이미지 업로드 실패", HttpStatus.INTERNAL_SERVER_ERROR),
+    EMAIL_SEND_FAILED("500-C003", "메일 발송 실패", HttpStatus.INTERNAL_SERVER_ERROR),
+    JSON_PARSING_ERROR("500-C004", "JSON 파싱 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    // AI 인공지능 오류 - 기존에 모두 500으로 처리되던 코드를 AI001~AI004로 분리하여 장애 추적 용이성 확보
+    AI_TIMEOUT("500-AI001", "AI 응답 시간 초과", HttpStatus.INTERNAL_SERVER_ERROR),
+    AI_ERROR("500-AI002", "AI 처리 중 오류 발생", HttpStatus.INTERNAL_SERVER_ERROR),
+    AI_NO_RESPONSE("500-AI003", "AI로부터 응답을 받지 못했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    AI_INVALID_JSON("500-AI004", "AI 응답이 유효한 JSON 형식이 아닙니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     // 메시지에 동적 인자가 필요한 경우 사용 (String.format 기능)
     fun getMessageWithArgs(vararg args: Any?): String {

--- a/backend/src/test/java/com/back/domain/item/item/controller/ItemControllerTest.kt
+++ b/backend/src/test/java/com/back/domain/item/item/controller/ItemControllerTest.kt
@@ -113,7 +113,7 @@ class ItemControllerTest {
             match(MockMvcResultMatchers.handler().handlerType(ItemController::class.java))
             match(MockMvcResultMatchers.handler().methodName("getItem"))
             status { isNotFound() }
-            jsonPath("$.resultCode") { value("404-1") }
+            jsonPath("$.resultCode") { value("404-I002") }
             jsonPath("$.msg") { value("존재하지 않는 아이템이거나 권한이 없습니다.") }
         }
     }
@@ -158,7 +158,7 @@ class ItemControllerTest {
             match(MockMvcResultMatchers.handler().handlerType(ItemController::class.java))
             match(MockMvcResultMatchers.handler().methodName("replaceItem"))
             status { isNotFound() }
-            jsonPath("$.resultCode") { value("404-1") }
+            jsonPath("$.resultCode") { value("404-I002") }
             jsonPath("$.msg") { value("존재하지 않는 아이템이거나 권한이 없습니다.") }
         }
     }
@@ -225,7 +225,7 @@ class ItemControllerTest {
             match(MockMvcResultMatchers.handler().handlerType(ItemController::class.java))
             match(MockMvcResultMatchers.handler().methodName("modifyItem"))
             status { isNotFound() }
-            jsonPath("$.resultCode") { value("404-1") }
+            jsonPath("$.resultCode") { value("404-I002") }
             jsonPath("$.msg") { value("존재하지 않는 아이템이거나 권한이 없습니다.") }
         }
     }
@@ -255,7 +255,7 @@ class ItemControllerTest {
             match(MockMvcResultMatchers.handler().handlerType(ItemController::class.java))
             match(MockMvcResultMatchers.handler().methodName("modifyItem"))
             status { isNotFound() }
-            jsonPath("$.resultCode") { value("404-1") }
+            jsonPath("$.resultCode") { value("404-I003") }
             jsonPath("$.msg") { value("존재하지 않는 카테고리입니다.") }
         }
     }
@@ -285,7 +285,7 @@ class ItemControllerTest {
             match(MockMvcResultMatchers.handler().handlerType(ItemController::class.java))
             match(MockMvcResultMatchers.handler().methodName("modifyItem"))
             status { isBadRequest() }
-            jsonPath("$.resultCode") { value("400-1") }
+            jsonPath("$.resultCode") { value("400-C001") }
             jsonPath("$.msg") { value("cycleDays 형식이 올바르지 않습니다. 예: 30d, 2m, 1y") }
         }
     }
@@ -394,7 +394,7 @@ class ItemControllerTest {
             match(MockMvcResultMatchers.handler().handlerType(ItemController::class.java))
             match(MockMvcResultMatchers.handler().methodName("createItem"))
             status { isBadRequest() }
-            jsonPath("$.resultCode") { value("400-1") }
+            jsonPath("$.resultCode") { value("400-C001") }
         }
     }
 
@@ -416,7 +416,7 @@ class ItemControllerTest {
             match(MockMvcResultMatchers.handler().handlerType(ItemController::class.java))
             match(MockMvcResultMatchers.handler().methodName("createItem"))
             status { isBadRequest() }
-            jsonPath("$.resultCode") { value("400-1") }
+            jsonPath("$.resultCode") { value("400-C001") }
         }
     }
 
@@ -438,7 +438,7 @@ class ItemControllerTest {
             match(MockMvcResultMatchers.handler().handlerType(ItemController::class.java))
             match(MockMvcResultMatchers.handler().methodName("createItem"))
             status { isBadRequest() }
-            jsonPath("$.resultCode") { value("400-1") }
+            jsonPath("$.resultCode") { value("400-C001") }
         }
     }
 
@@ -461,7 +461,7 @@ class ItemControllerTest {
             match(MockMvcResultMatchers.handler().handlerType(ItemController::class.java))
             match(MockMvcResultMatchers.handler().methodName("createItem"))
             status { isBadRequest() }
-            jsonPath("$.resultCode") { value("400-1") }
+            jsonPath("$.resultCode") { value("400-C001") }
             jsonPath("$.msg") { value("cycleDays 형식이 올바르지 않습니다. 예: 30d, 2m, 1y") }
         }
     }
@@ -485,7 +485,7 @@ class ItemControllerTest {
             match(MockMvcResultMatchers.handler().handlerType(ItemController::class.java))
             match(MockMvcResultMatchers.handler().methodName("createItem"))
             status { isNotFound() }
-            jsonPath("$.resultCode") { value("404-1") }
+            jsonPath("$.resultCode") { value("404-I003") }
             jsonPath("$.msg") { value("존재하지 않는 카테고리입니다.") }
         }
     }
@@ -509,7 +509,7 @@ class ItemControllerTest {
             match(MockMvcResultMatchers.handler().handlerType(ItemController::class.java))
             match(MockMvcResultMatchers.handler().methodName("createItem"))
             status { isBadRequest() }
-            jsonPath("$.resultCode") { value("400-1") }
+            jsonPath("$.resultCode") { value("400-C001") }
             jsonPath("$.msg") { value("cycleDays 값은 1 이상이어야 합니다.") }
         }
     }
@@ -575,7 +575,7 @@ class ItemControllerTest {
             match(MockMvcResultMatchers.handler().handlerType(ItemController::class.java))
             match(MockMvcResultMatchers.handler().methodName("deleteItem"))
             status { isNotFound() }
-            jsonPath("$.resultCode") { value("404-1") }
+            jsonPath("$.resultCode") { value("404-I002") }
             jsonPath("$.msg") { value("존재하지 않는 아이템이거나 권한이 없습니다.") }
         }
     }
@@ -596,7 +596,7 @@ class ItemControllerTest {
             match(MockMvcResultMatchers.handler().handlerType(ItemController::class.java))
             match(MockMvcResultMatchers.handler().methodName("deleteItem"))
             status { isNotFound() }
-            jsonPath("$.resultCode") { value("404-1") }
+            jsonPath("$.resultCode") { value("404-I002") }
             jsonPath("$.msg") { value("존재하지 않는 아이템이거나 권한이 없습니다.") }
         }
     }

--- a/backend/src/test/java/com/back/domain/user/user/controller/ApiV1UserControllerTest.kt
+++ b/backend/src/test/java/com/back/domain/user/user/controller/ApiV1UserControllerTest.kt
@@ -73,7 +73,7 @@ class ApiV1UserControllerTest {
                 .content("{\"password\":\"test123\",\"email\":\"test@test.com\"}")
         )
             .andExpect(MockMvcResultMatchers.status().isBadRequest())
-            .andExpect(MockMvcResultMatchers.jsonPath("$.resultCode").value("400-1"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.resultCode").value("400-C002"))
     }
 
     @Test
@@ -487,7 +487,7 @@ class ApiV1UserControllerTest {
         )
             .andDo(MockMvcResultHandlers.print())
             .andExpect(MockMvcResultMatchers.status().isUnauthorized()) // 400 대신 401을 기대하도록 수정
-            .andExpect(MockMvcResultMatchers.jsonPath("$.resultCode").value("401-1"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.resultCode").value("401-U003"))
             .andExpect(MockMvcResultMatchers.jsonPath("$.msg").value("비밀번호가 일치하지 않습니다."))
     }
 


### PR DESCRIPTION
## 작업 내용

`ErrorCode.kt` 내 여러 예외 상황에서 동일한 코드(`400-1`, `401-1`, `500` 등)가 중복 사용되던 문제를 해결
클라이언트 측의 원활한 예외 처리(에러별 별도 모달/안내 등)와 서버 로그 추적의 명확성을 높이기 위해 **도메인 기반의 하이브리드 네이밍 포맷**을 새롭게 도입

더불어, 에러 코드 포맷이 변경됨에 따라 실패하던 기존 통합 테스트 코드들의 검증 로직을 새로운 포맷에 맞게 모두 수정하여 빌드 안정성을 확보

## 주요 변경 사항

* **ErrorCode 포맷 변경:** 단순 `숫자-숫자` 형태에서 `{HTTP상태코드}-{도메인접두사}{일련번호}` 형태로 개선
* **도메인 분류 기준 적용:** 성격에 따라 4가지 도메인으로 세분화 및 식별자 고유화
* **C (Common/System):** 공통 입력/시스템 예외 (예: `400-C001`, `500-C001`)
* **U (User/Auth):** 인증 및 유저 관련 예외 (예: `401-U001`, `403-U001`)
* **I (Item/Category):** 아이템 및 카테고리 예외 (예: `404-I001`)
* **AI (Artificial Intelligence):** AI 처리 관련 예외 (예: `500-AI001`)


* **코드 가독성 향상:** 코드 변경 사유 및 도메인 분류 기준을 이해하기 쉽도록 `ErrorCode.kt` 내부에 상세 주석 추가 완료
* * 테스트 코드 검증 로직 동기화:** * `ItemControllerTest.kt` 및 `ApiV1UserControllerTest.kt` 등에서 기존 포맷(`400-1`, `404-1` 등)을 기대(`Expected`)하여 발생하는 `AssertionError` 해결
* 실제 반환되는 신규 도메인 에러 코드(`Actual` 값, 예: `400-C001`, `404-I002`, `401-U003` 등)에 맞춰 `jsonPath("$.resultCode").value(...)` 검증부 전면 수정 완료



## 기술적 의사결정

에러 코드를 단순히 문자열(`C001`, `U001`)로 변경하지 않고 앞부분에 HTTP 상태 코드를 유지한 이유는 **서버 장애를 방지하기 위한 하위 호환성 유지** 때문

* 현재 `RsData.kt` 및 `ServiceException.kt`는 `resultCode.substringBefore("-").toInt()`를 통해 상태 코드를 동적으로 계산
* 파싱 로직(`toInt()`)에서 발생할 수 있는 `NumberFormatException`을 예방하고, 기존 코어 클래스의 수정 비용을 최소화하기 위해 `-` 기호를 기준으로 앞은 숫자(상태코드), 뒤는 문자(도메인 식별자)가 오는 구조를 채택

## AS-IS vs TO-BE

### 1. ErrorCode.kt

**AS-IS (기존)**

```kotlin
INVALID_INPUT_VALUE("400-1", "잘못된 입력값입니다.", HttpStatus.BAD_REQUEST),
INVALID_REQUEST_BODY("400-1", "요청 본문이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
SAME_PASSWORD("400-1", "새 비밀번호는 현재 비밀번호와 달라야 합니다.", HttpStatus.BAD_REQUEST),

```

**TO-BE (변경 후)**

```kotlin
// 공통(C) 요청 오류
INVALID_INPUT_VALUE("400-C001", "잘못된 입력값입니다.", HttpStatus.BAD_REQUEST),
INVALID_REQUEST_BODY("400-C002", "요청 본문이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
// 유저(U) 관련 잘못된 요청
SAME_PASSWORD("400-U001", "새 비밀번호는 현재 비밀번호와 달라야 합니다.", HttpStatus.BAD_REQUEST),

```

### 2. Test 코드

**AS-IS (기존)**

```kotlin
// ItemControllerTest.kt
.andExpect(MockMvcResultMatchers.jsonPath("$.resultCode").value("400-1"))

```

**TO-BE (변경 후)**

```kotlin
// ItemControllerTest.kt
.andExpect(MockMvcResultMatchers.jsonPath("$.resultCode").value("400-C001"))

```