### PR TITLE
refactor: UserService 유효성 검증 어노테이션 제거

### DIFF
--- a/backend/src/main/java/com/back/domain/user/user/service/UserService.kt
+++ b/backend/src/main/java/com/back/domain/user/user/service/UserService.kt
@@ -78,7 +78,7 @@ class UserService(
     @Transactional
     fun updateProfile(
         id: Long,
-        @NotBlank @Size(min = 2, max = 30) email: String
+        email: String
     ): User {
         val user = userRepository.findById(id)
             .orElseThrow { ServiceException(ErrorCode.USER_NOT_FOUND) }
@@ -101,8 +101,8 @@ class UserService(
     @Transactional
     fun changePassword(
         id: Long,
-        @NotBlank @Size(min = 2, max = 30) currentPassword: String,
-        @NotBlank @Size(min = 2, max = 30) newPassword: String
+        currentPassword: String,
+        newPassword: String
     ): User {
         val user = userRepository.findById(id)
             .orElseThrow { ServiceException(ErrorCode.USER_NOT_FOUND) }

--- a/backend/src/main/java/com/back/domain/user/user/service/UserService.kt
+++ b/backend/src/main/java/com/back/domain/user/user/service/UserService.kt
@@ -6,8 +6,6 @@ import com.back.global.exception.ErrorCode
 import com.back.global.exception.ServiceException
 import com.back.global.s3.S3ImageService
 import org.springframework.transaction.annotation.Transactional
-import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.Size
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import java.util.*


### PR DESCRIPTION
## 작업 내용
`UserService`의 메서드 파라미터에 선언되어 있던 불필요한 유효성 검증 어노테이션(`@NotBlank`, `@Size`)을 제거하여 코드 가독성을 높이고 계층 간 역할을 명확히 분리

## 주요 변경 사항
- `UserService.updateProfile()` 및 `changePassword()` 메서드의 파라미터 유효성 검증 어노테이션 제거

**변경 이유:**
1. **동작하지 않는 코드 (Dead Code):** Service 클래스 레벨에 `@Validated` 어노테이션이 선언되어 있지 않아, 파라미터 레벨의 검증 어노테이션이 실제로 작동하지 않는 상태
2. **중복 검증 제거 및 역할 분리:** `ApiV1UserController`와 각 DTO(`UserProfileUpdateRequest`, `PasswordChangeRequest`)에서 이미 `@Valid`를 통해 엄격한 입력값 1차 검증을 수행. Service 계층은 데이터 형식 검증보다는 핵심 비즈니스 로직(데이터베이스 상태 확인 등)에 집중하는 것이 적절하다고 판단