### PR TITLE
refactor: User 엔티티 식별자 패턴 개선 및 연관 모듈 타입 불일치 해결

### DIFF
--- a/backend/src/main/java/com/back/domain/email/controller/EmailController.kt
+++ b/backend/src/main/java/com/back/domain/email/controller/EmailController.kt
@@ -44,7 +44,7 @@ class EmailController (
             response["recipientEmail"] = sentToEmail
             response["itemId"] = itemId
             response["itemName"] = itemName
-            response["userId"] = user.id!!
+            response["userId"] = user.persistedId
             response["userLoginId"] = user.loginId
 
             ResponseEntity.ok(response)

--- a/backend/src/main/java/com/back/domain/email/controller/EmailController.kt
+++ b/backend/src/main/java/com/back/domain/email/controller/EmailController.kt
@@ -44,7 +44,7 @@ class EmailController (
             response["recipientEmail"] = sentToEmail
             response["itemId"] = itemId
             response["itemName"] = itemName
-            response["userId"] = user.id
+            response["userId"] = user.id!!
             response["userLoginId"] = user.loginId
 
             ResponseEntity.ok(response)

--- a/backend/src/main/java/com/back/domain/item/item/controller/ItemController.kt
+++ b/backend/src/main/java/com/back/domain/item/item/controller/ItemController.kt
@@ -1,7 +1,6 @@
 package com.back.domain.item.item.controller
 
 import com.back.domain.item.item.dto.*
-import com.back.domain.item.item.entity.Item
 import com.back.domain.item.item.service.ItemRecommendationService
 import com.back.domain.item.item.service.ItemService
 import com.back.domain.item.item.service.ItemStatisticsService
@@ -10,7 +9,6 @@ import com.back.global.rsData.RsData
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
-import org.springframework.data.jpa.domain.AbstractPersistable_.id
 import org.springframework.http.MediaType
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*

--- a/backend/src/main/java/com/back/domain/item/item/dto/ItemReplaceResponse.kt
+++ b/backend/src/main/java/com/back/domain/item/item/dto/ItemReplaceResponse.kt
@@ -26,8 +26,8 @@ data class ItemReplaceResponse(
         @JvmStatic
         fun from(item: Item): ItemReplaceResponse {
             return ItemReplaceResponse(
-                id = item.id!!,
-                item.user!!.id!!,
+                id = item.id!!, // Item 엔티티도 추후 persistedId 도입을 고려EmailController
+                userId = item.user!!.persistedId, // id!! -> persistedId 로 변경
                 if (item.category == null) null else item.category!!.id,
                 if (item.category == null) null else item.category!!.name,
                 name = item.name ?: "",

--- a/backend/src/main/java/com/back/domain/item/item/dto/ItemReplaceResponse.kt
+++ b/backend/src/main/java/com/back/domain/item/item/dto/ItemReplaceResponse.kt
@@ -27,7 +27,7 @@ data class ItemReplaceResponse(
         fun from(item: Item): ItemReplaceResponse {
             return ItemReplaceResponse(
                 id = item.id!!,
-                item.user!!.id,
+                item.user!!.id!!,
                 if (item.category == null) null else item.category!!.id,
                 if (item.category == null) null else item.category!!.name,
                 name = item.name ?: "",

--- a/backend/src/main/java/com/back/domain/user/user/dto/UserDto.kt
+++ b/backend/src/main/java/com/back/domain/user/user/dto/UserDto.kt
@@ -17,7 +17,7 @@ data class UserDto(
         @JvmStatic
         fun from(user: User): UserDto =
             UserDto(
-                user.id,
+                user.id!!,
                 user.loginId,
                 user.email
             )

--- a/backend/src/main/java/com/back/domain/user/user/dto/UserDto.kt
+++ b/backend/src/main/java/com/back/domain/user/user/dto/UserDto.kt
@@ -17,7 +17,7 @@ data class UserDto(
         @JvmStatic
         fun from(user: User): UserDto =
             UserDto(
-                user.id!!,
+                user.persistedId,
                 user.loginId,
                 user.email
             )

--- a/backend/src/main/java/com/back/domain/user/user/dto/UserUpdateResponse.kt
+++ b/backend/src/main/java/com/back/domain/user/user/dto/UserUpdateResponse.kt
@@ -17,7 +17,7 @@ data class UserUpdateResponse(
         @JvmStatic
         fun from(user: User): UserUpdateResponse {
             return UserUpdateResponse(
-                user.id,
+                user.id!!,
                 user.loginId,
                 user.email
             )

--- a/backend/src/main/java/com/back/domain/user/user/dto/UserUpdateResponse.kt
+++ b/backend/src/main/java/com/back/domain/user/user/dto/UserUpdateResponse.kt
@@ -17,7 +17,7 @@ data class UserUpdateResponse(
         @JvmStatic
         fun from(user: User): UserUpdateResponse {
             return UserUpdateResponse(
-                user.id!!,
+                user.persistedId,
                 user.loginId,
                 user.email
             )

--- a/backend/src/main/java/com/back/domain/user/user/entity/User.kt
+++ b/backend/src/main/java/com/back/domain/user/user/entity/User.kt
@@ -30,6 +30,9 @@ class User(
     var id: Long? = null
         protected set
 
+    val persistedId: Long
+        get() = id ?: throw IllegalStateException("User 엔티티가 아직 영속화되지 않았습니다. (id is null)")
+
     protected constructor() : this(
         loginId = "",
         password = "",

--- a/backend/src/main/java/com/back/domain/user/user/entity/User.kt
+++ b/backend/src/main/java/com/back/domain/user/user/entity/User.kt
@@ -27,11 +27,8 @@ class User(
 ) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var _id: Long? = null
+    var id: Long? = null
         protected set
-
-    val id: Long
-        get() = _id ?: error("User is not persisted yet (id is null)")
 
     protected constructor() : this(
         loginId = "",

--- a/backend/src/main/java/com/back/global/initData/BaseInitData.kt
+++ b/backend/src/main/java/com/back/global/initData/BaseInitData.kt
@@ -69,7 +69,7 @@ class BaseInitData(
 
         // user1.getId() 같은 Getter 메서드 대신 프로퍼티 접근 구문(user1.id)을 사용
         itemService.createItem(
-            user1.id!!,
+            user1.persistedId,
             ItemCreateRequest(
                 categoryId = bathroom.id!!,
                 name = "칫솔",
@@ -81,7 +81,7 @@ class BaseInitData(
         )
 
         itemService.createItem(
-            user1.id!!,
+            user1.persistedId,
             ItemCreateRequest(
                 categoryId = kitchen.id!!,
                 name = "수세미",
@@ -93,7 +93,7 @@ class BaseInitData(
         )
 
         itemService.createItem(
-            user2.id!!,
+            user2.persistedId,
             ItemCreateRequest(
                 categoryId = car.id!!,
                 name = "엔진오일",
@@ -105,7 +105,7 @@ class BaseInitData(
         )
 
         itemService.createItem(
-            user1.id!!,
+            user1.persistedId,
             ItemCreateRequest(
                 categoryId = bathroom.id!!,
                 name = "테스트용 칫솔 (D-Day 0)",

--- a/backend/src/main/java/com/back/global/initData/BaseInitData.kt
+++ b/backend/src/main/java/com/back/global/initData/BaseInitData.kt
@@ -69,7 +69,7 @@ class BaseInitData(
 
         // user1.getId() 같은 Getter 메서드 대신 프로퍼티 접근 구문(user1.id)을 사용
         itemService.createItem(
-            user1.id,
+            user1.id!!,
             ItemCreateRequest(
                 categoryId = bathroom.id!!,
                 name = "칫솔",
@@ -81,7 +81,7 @@ class BaseInitData(
         )
 
         itemService.createItem(
-            user1.id,
+            user1.id!!,
             ItemCreateRequest(
                 categoryId = kitchen.id!!,
                 name = "수세미",
@@ -93,7 +93,7 @@ class BaseInitData(
         )
 
         itemService.createItem(
-            user2.id,
+            user2.id!!,
             ItemCreateRequest(
                 categoryId = car.id!!,
                 name = "엔진오일",
@@ -105,7 +105,7 @@ class BaseInitData(
         )
 
         itemService.createItem(
-            user1.id,
+            user1.id!!,
             ItemCreateRequest(
                 categoryId = bathroom.id!!,
                 name = "테스트용 칫솔 (D-Day 0)",

--- a/backend/src/main/java/com/back/global/security/CustomAuthenticationFilter.kt
+++ b/backend/src/main/java/com/back/global/security/CustomAuthenticationFilter.kt
@@ -157,7 +157,7 @@ class CustomAuthenticationFilter(
 
         // 9) SecurityContext에 인증 정보 주입
         val securityUser: UserDetails = SecurityUser(
-            user.id!!,
+            user.persistedId,
             user.loginId,
             "",
             user.email ?: "",

--- a/backend/src/main/java/com/back/global/security/CustomAuthenticationFilter.kt
+++ b/backend/src/main/java/com/back/global/security/CustomAuthenticationFilter.kt
@@ -157,7 +157,7 @@ class CustomAuthenticationFilter(
 
         // 9) SecurityContext에 인증 정보 주입
         val securityUser: UserDetails = SecurityUser(
-            user.id,
+            user.id!!,
             user.loginId,
             "",
             user.email ?: "",

--- a/backend/src/test/java/com/back/domain/item/itemHistory/service/ItemHistoryServiceTest.kt
+++ b/backend/src/test/java/com/back/domain/item/itemHistory/service/ItemHistoryServiceTest.kt
@@ -94,7 +94,7 @@ internal class ItemHistoryServiceTest {
     @DisplayName("특정 아이템 이력 조회 - 성공: 이력이 없으면 빈 리스트 반환")
     fun getItemHistories_empty() {
         // 이력이 없는 상태에서 조회 시 빈 리스트가 반환되는지 확인
-        val responses = itemHistoryService.getItemHistories(item.id!!, user.id)
+        val responses = itemHistoryService.getItemHistories(item.id!!, user.id!!)
         assertThat(responses).isEmpty()
     }
 
@@ -103,7 +103,7 @@ internal class ItemHistoryServiceTest {
     fun getItemHistories_dto_mapping() {
         // 이력 생성 후 조회
         itemHistoryService.createItemHistory(item)
-        val responses = itemHistoryService.getItemHistories(item.id!!, user.id)
+        val responses = itemHistoryService.getItemHistories(item.id!!, user.id!!)
 
         // 조회된 DTO가 아이템 ID, 시작일 등 데이터를 올바르게 매핑했는지 검증
         assertThat(responses).hasSize(1)
@@ -121,7 +121,7 @@ internal class ItemHistoryServiceTest {
         itemHistoryService.createItemHistory(item)
 
         // 조회 시 최신순(시작일 내림차순)으로 정렬되어 반환되는지 확인
-        val responses = itemHistoryService.getItemHistories(item.id!!, user.id)
+        val responses = itemHistoryService.getItemHistories(item.id!!, user.id!!)
 
         assertThat(responses).hasSize(2)
         assertThat(responses[0].startDate).isAfterOrEqualTo(responses[1].startDate)
@@ -131,7 +131,7 @@ internal class ItemHistoryServiceTest {
     @DisplayName("전체 아이템 이력 조회 - 성공: 이력이 없으면 빈 리스트 반환")
     fun getAllItemHistories_empty() {
         // 유저의 모든 아이템 이력 조회 시 데이터가 없으면 빈 리스트 반환 검증
-        val responses = itemHistoryService.getAllItemHistories(user.id)
+        val responses = itemHistoryService.getAllItemHistories(user.id!!)
         assertThat(responses).isEmpty()
     }
 
@@ -158,7 +158,7 @@ internal class ItemHistoryServiceTest {
         itemHistoryService.createItemHistory(otherItem)
 
         // 내 이력 조회 시, 다른 유저의 데이터는 제외되고 내 데이터만 조회되는지 확인
-        val responses = itemHistoryService.getAllItemHistories(user.id)
+        val responses = itemHistoryService.getAllItemHistories(user.id!!)
 
         assertThat(responses).hasSize(1)
         assertThat(responses[0].itemName).isEqualTo(item.name)
@@ -170,7 +170,7 @@ internal class ItemHistoryServiceTest {
     fun getAllItemHistories_dto_mapping() {
         itemHistoryService.createItemHistory(item)
 
-        val responses = itemHistoryService.getAllItemHistories(user.id)
+        val responses = itemHistoryService.getAllItemHistories(user.id!!)
 
         // 전체 이력 DTO에 카테고리 이름, 이미지 URL 등이 포함되어 있는지 검증
         assertThat(responses).hasSize(1)
@@ -248,7 +248,7 @@ internal class ItemHistoryServiceTest {
 
         // 다른 유저(stranger)가 내 아이템의 이력을 조회하려 할 때 예외(권한 없음) 발생 확인
         val exception = assertThrows<ServiceException> {
-            itemHistoryService.getItemHistories(item.id!!, stranger.id)
+            itemHistoryService.getItemHistories(item.id!!, stranger.id!!)
         }
 
         // ITEM_NOT_FOUND_OR_NO_PERMISSION 에러 코드 검증

--- a/backend/src/test/java/com/back/domain/item/itemHistory/service/ItemHistoryServiceTest.kt
+++ b/backend/src/test/java/com/back/domain/item/itemHistory/service/ItemHistoryServiceTest.kt
@@ -94,7 +94,7 @@ internal class ItemHistoryServiceTest {
     @DisplayName("특정 아이템 이력 조회 - 성공: 이력이 없으면 빈 리스트 반환")
     fun getItemHistories_empty() {
         // 이력이 없는 상태에서 조회 시 빈 리스트가 반환되는지 확인
-        val responses = itemHistoryService.getItemHistories(item.id!!, user.id!!)
+        val responses = itemHistoryService.getItemHistories(item.id!!, user.persistedId)
         assertThat(responses).isEmpty()
     }
 
@@ -131,7 +131,7 @@ internal class ItemHistoryServiceTest {
     @DisplayName("전체 아이템 이력 조회 - 성공: 이력이 없으면 빈 리스트 반환")
     fun getAllItemHistories_empty() {
         // 유저의 모든 아이템 이력 조회 시 데이터가 없으면 빈 리스트 반환 검증
-        val responses = itemHistoryService.getAllItemHistories(user.id!!)
+        val responses = itemHistoryService.getAllItemHistories(user.persistedId)
         assertThat(responses).isEmpty()
     }
 
@@ -248,7 +248,7 @@ internal class ItemHistoryServiceTest {
 
         // 다른 유저(stranger)가 내 아이템의 이력을 조회하려 할 때 예외(권한 없음) 발생 확인
         val exception = assertThrows<ServiceException> {
-            itemHistoryService.getItemHistories(item.id!!, stranger.id!!)
+            itemHistoryService.getItemHistories(item.id!!, stranger.persistedId)
         }
 
         // ITEM_NOT_FOUND_OR_NO_PERMISSION 에러 코드 검증

--- a/backend/src/test/java/com/back/domain/user/user/service/AuthTokenServiceTest.kt
+++ b/backend/src/test/java/com/back/domain/user/user/service/AuthTokenServiceTest.kt
@@ -53,7 +53,7 @@ internal class AuthTokenServiceTest {
     @DisplayName("payload(): 모든 클레임(id, loginId, email, version)을 정확히 추출")
     fun payload_extracts_all_claims() {
         val user = User("payloadTestUser", "password123", "payload@test.com").apply {
-            ReflectionTestUtils.setField(this, "_id", 456L)
+            ReflectionTestUtils.setField(this, "id", 456L)
             repeat(3) { increaseTokenVersion() }
         }
 
@@ -109,7 +109,7 @@ internal class AuthTokenServiceTest {
     @DisplayName("payload(): 숫자 타입(ID, Version)은 Long 값으로 정확히 비교")
     fun payload_handles_number_types_correctly() {
         val user = User("numberTestUser", "password", "number@test.com").apply {
-            ReflectionTestUtils.setField(this, "_id", 999_999_999L)
+            ReflectionTestUtils.setField(this, "id", 999_999_999L)
             repeat(5) { increaseTokenVersion() }
         }
 
@@ -150,7 +150,7 @@ internal class AuthTokenServiceTest {
     }
 
     private fun User.withId(id: Long): User = apply {
-        ReflectionTestUtils.setField(this, "_id", id)
+        ReflectionTestUtils.setField(this, "id", id)
     }
 
     //Long으로 전환

--- a/backend/src/test/java/com/back/global/security/SecurityIntegrationTest.kt
+++ b/backend/src/test/java/com/back/global/security/SecurityIntegrationTest.kt
@@ -53,7 +53,7 @@ internal class SecurityIntegrationTest {
     private fun createAccessToken(user: User): String =
         createAccessToken(
             mapOf(
-                "id" to user.id,
+                "id" to user.id!!,
                 "loginId" to user.loginId,
                 "email" to (user.email ?: ""),
                 "tokenVersion" to user.tokenVersion


### PR DESCRIPTION
## 작업 내용

`User` 엔티티 내부에서 사용되던 비표준 식별자 패턴(`_id` 프로퍼티 및 Custom Getter)을 제거하고, JPA 및 Kotlin 컨벤션에 맞는 표준 패턴(`id: Long?`)으로 리팩토링
이에 따라 발생한 DTO, Controller, Test 코드의 Null-Safety 타입 불일치 및 리플렉션 오류를 모두 수정하여 빌드 및 테스트를 정상화

### **변경 사항**

**1. 엔티티 구조 개선**

* `User` 엔티티의 `_id` 필드 및 강제 예외 발생을 담당하던 `val id: Long` Getter 제거
* 다른 엔티티(`Category` 등)와의 일관성을 위해 식별자를 `var id: Long? = null protected set`으로 변경

**2. Null-Safety 대응 및 연관 코드 수정**

* `id`가 Nullable(`Long?`)로 변경됨에 따라, 영속화가 보장된 로직 내에서 강제 단언 연산자(`!!`)를 적용하여 기존 로직과 동일하게 동작하도록 수정
* **수정된 파일 목록**:
* `EmailController.kt`
* `ItemReplaceResponse.kt`, `UserDto.kt`, `UserUpdateResponse.kt`
* `BaseInitData.kt`
* `CustomAuthenticationFilter.kt`



**3. 테스트 코드 정상화**

* `SecurityIntegrationTest`, `ItemHistoryServiceTest`: `id` 파라미터 전달 시 `!!` 연산자 추가하여 컴파일 에러 해결
* `AuthTokenServiceTest`: `ReflectionTestUtils`를 통해 주입하던 필드 이름을 `_id`에서 `id`로 수정하여 `IllegalArgumentException` 해결

### **변경 사유**
이 패턴을 사용한 의도는 "비즈니스 로직 상에서 엔티티의 ID를 사용할 때 매번 Null-check(?. 또는 !!)를 하는 번거로움을 없애고, 영속화되지 않은 상태에서 ID에 접근하는 실수를 방지(Fail-fast)하겠다"는 것으로 보이지만 다음과 같은 이유로 변경

* **일관성 확보**: 프로젝트 내 다른 엔티티들과 식별자를 다루는 방식을 통일하여 협업 시 혼란을 방지
* **JPA 호환성**: JPA는 비영속 상태(Transient)에서 식별자가 `null`인 것을 기본으로 전제. 기존의 예외를 던지는 Getter 방식은 Spring Data JPA의 내부 동작(save 시점의 isNew 판단 등)과 충돌하거나 뜻하지 않은 오류를 발생시킬 여지가 있어 이를 선제적으로 개선