### PR TITLE
[OBSOLETE] fix: [CICD] GHCR 이미지 경로 소문자 하드코딩

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,8 +7,8 @@ on:
   workflow_dispatch:
 
 env:
-  # 퍼블릭 IP 기반 운영 값입니다. 인스턴스 IP가 바뀌면 이 값도 함께 수정해야 합니다.
-  PUBLIC_API_BASE_URL: http://100.53.52.159/api
+  # AWS_SERVER_HOST(호스트/IP) 하나만 변경하면 프론트 API 주소도 함께 반영됩니다.
+  PUBLIC_API_BASE_URL: http://${{ secrets.AWS_SERVER_HOST }}
 
 permissions:
   contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,8 +61,8 @@ jobs:
       - name: Set image metadata
         id: meta
         run: |
-          echo "backend_image=ghcr.io/${{ github.repository }}/backend:${{ github.sha }}" >> "$GITHUB_OUTPUT"
-          echo "frontend_image=ghcr.io/${{ github.repository }}/frontend:${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          echo "backend_image=ghcr.io/prgrms-be-devcourse/nbe8-10-3-team04/backend:${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          echo "frontend_image=ghcr.io/prgrms-be-devcourse/nbe8-10-3-team04/frontend:${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push backend image
         uses: docker/build-push-action@v5
@@ -71,7 +71,7 @@ jobs:
           push: true
           tags: |
             ${{ steps.meta.outputs.backend_image }}
-            ghcr.io/${{ github.repository }}/backend:latest
+            ghcr.io/prgrms-be-devcourse/nbe8-10-3-team04/backend:latest
 
       - name: Build and push frontend image
         uses: docker/build-push-action@v5
@@ -82,7 +82,7 @@ jobs:
             NEXT_PUBLIC_API_BASE_URL=${{ env.PUBLIC_API_BASE_URL }}
           tags: |
             ${{ steps.meta.outputs.frontend_image }}
-            ghcr.io/${{ github.repository }}/frontend:latest
+            ghcr.io/prgrms-be-devcourse/nbe8-10-3-team04/frontend:latest
 
   deploy:
     runs-on: ubuntu-latest

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -173,7 +173,8 @@ echo green > deploy/ACTIVE_COLOR
 - `GEMINI_API_KEY`
 
 참고:
-- `NEXT_PUBLIC_API_BASE_URL`은 현재 워크플로우 파일 내 `PUBLIC_API_BASE_URL` 환경값으로 관리
+- `NEXT_PUBLIC_API_BASE_URL`은 워크플로우에서 `AWS_SERVER_HOST`를 기준으로 자동 생성
+- `AWS_SERVER_HOST`에는 `http://`/`https://`/경로(`/api`) 없이 호스트(IP 또는 DNS)만 입력
 
 ---
 


### PR DESCRIPTION
이 PR은 히스토리 정리 과정에서 **폐기(Obsolete)** 처리되었습니다.

대체 작업은 아래 PR에서 진행합니다.

- 대체 PR: #156
- 기준 이슈: #155
- 신규 브랜치: `fix/cicd-bluegreen-deploy/155`

> 이 PR은 머지 대상이 아닙니다.